### PR TITLE
feat(packages): dropdown 컴포넌트 추가

### DIFF
--- a/packages/hooks/eslint.config.mjs
+++ b/packages/hooks/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from '@repo/eslint-config/react-internal';
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/hooks/index.ts
+++ b/packages/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useBooleanState } from './src/useBooleanState';
+export { default as useOutsideClick } from './src/useOutsideClick';

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@merried/hooks",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "generate:component": "turbo gen react-component",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "19.0.10",
+    "@types/react-dom": "19.0.4",
+    "eslint": "^9.23.0",
+    "styled-reset": "^4.4.7",
+    "typescript": "5.8.2"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
-    "@types/react": "19.0.10",
-    "@types/react-dom": "19.0.4",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "eslint": "^9.23.0",
     "styled-reset": "^4.4.7",
     "typescript": "5.8.2"

--- a/packages/hooks/src/useBooleanState.ts
+++ b/packages/hooks/src/useBooleanState.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+const useBooleanState = (initialValue?: boolean) => {
+  const [value, setValue] = useState(() => !!initialValue);
+
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
+  const toggle = useCallback(() => setValue((prev) => !prev), []);
+
+  return { value, setValue, setTrue, setFalse, toggle };
+};
+
+export default useBooleanState;

--- a/packages/hooks/src/useOutsideClick.ts
+++ b/packages/hooks/src/useOutsideClick.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+const useOutsideClick = (callback: () => void) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [callback]);
+
+  return ref;
+};
+
+export default useOutsideClick;

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["."],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -1,1 +1,2 @@
 export { default as IconAdd } from './src/IconAdd';
+export { default as IconArrow } from './src/IconArrow';

--- a/packages/icon/src/IconArrow.tsx
+++ b/packages/icon/src/IconArrow.tsx
@@ -1,0 +1,31 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+type IconArrowProps = SVGProps<SVGSVGElement> & {
+  direction?: 'top' | 'bottom';
+};
+
+const IconArrow = ({ direction = 'bottom', ...props }: IconArrowProps) => {
+  const rotation = direction === 'top' ? 'rotate(180 9 8)' : undefined;
+
+  return (
+    <svg
+      width={18}
+      height={16}
+      viewBox="0 0 18 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M15.6666 4.66602L8.99992 11.3327L2.33325 4.66602"
+        stroke="#B8B8B8"
+        strokeWidth={2}
+        strokeLinecap="square"
+        transform={rotation}
+      />
+    </svg>
+  );
+};
+
+export default IconArrow;

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -3,3 +3,5 @@ export { default as DesktopButton } from './src/Button/DesktopButton';
 export { default as ActionButton } from './src/Button/ActionButton';
 export { default as Input } from './src/Input/Input';
 export { default as Dropdown } from './src/Dropdown/Dropdown';
+export { default as Row } from './src/Flex/Row';
+export { default as Column } from './src/Flex/Column';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -2,3 +2,4 @@ export { default as Button } from './src/Button/Button';
 export { default as DesktopButton } from './src/Button/DesktopButton';
 export { default as ActionButton } from './src/Button/ActionButton';
 export { default as Input } from './src/Input/Input';
+export { default as Dropdown } from './src/Dropdown/Dropdown';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "@merried/design-system": "workspace:*",
     "@merried/utils": "workspace:*",
     "@merried/icon": "workspace:*",
+    "@merried/hooks": "workspace:*",
     "@turbo/gen": "^2.4.4",
     "@types/node": "^22.13.10",
     "@types/react": "19.0.10",

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -4,21 +4,21 @@ import { flex } from '@merried/utils';
 import { color, font } from '@merried/design-system';
 import { IconArrow } from '@merried/icon';
 
-type DropdownOption = 'LARGE' | 'COLOR';
+type DropdownOption = 'DEFAULT' | 'COLOR';
 
 interface Props {
   onChange: (value: string, name: string) => void;
   name: string;
   value?: string;
   data?: string[];
-  size?: DropdownOption;
+  option?: DropdownOption;
   placeholder?: string;
 }
 
 const Dropdown = ({
   value,
   data,
-  size = 'LARGE',
+  option = 'DEFAULT',
   onChange,
   name,
   placeholder,
@@ -37,7 +37,7 @@ const Dropdown = ({
 
   return (
     <div ref={dropdownRef}>
-      <StyledDropdown onClick={handleToggleButtonClick} $isOpen={isOpen} $size={size}>
+      <StyledDropdown onClick={handleToggleButtonClick} $isOpen={isOpen} $option={option}>
         {value || placeholder}
         <IconArrow direction={isOpen ? 'top' : 'bottom'} />
       </StyledDropdown>
@@ -59,9 +59,9 @@ const Dropdown = ({
 
 export default Dropdown;
 
-const StyledDropdown = styled.div<{ $isOpen: boolean; $size: DropdownOption }>`
+const StyledDropdown = styled.div<{ $isOpen: boolean; $option: DropdownOption }>`
   ${flex({ alignItems: 'center', justifyContent: 'space-between' })}
-  width: ${({ $size }) => ($size === 'LARGE' ? '384px' : '334px')};
+  width: ${({ $option }) => ($option === 'DEFAULT' ? '384px' : '334px')};
   height: 42px;
   padding: 14px 16px;
   border: 1px solid ${({ $isOpen }) => ($isOpen ? color.G500 : color.G70)};

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -1,0 +1,109 @@
+import { styled } from 'styled-components';
+import { useBooleanState, useOutsideClick } from '@merried/hooks';
+import { flex } from '@merried/utils';
+import { color, font } from '@merried/design-system';
+
+type DropdownOption = 'LARGE' | 'COLOR';
+
+interface Props {
+  onChange: (value: string, name: string) => void;
+  name: string;
+  value?: string;
+  data?: string[];
+  size?: DropdownOption;
+  placeholder?: string;
+}
+
+const Dropdown = ({
+  value,
+  data,
+  size = 'LARGE',
+  onChange,
+  name,
+  placeholder,
+}: Props) => {
+  const {
+    value: isOpen,
+    setFalse: closeDropdown,
+    toggle: handleToggleButtonClick,
+  } = useBooleanState();
+  const dropdownRef = useOutsideClick(closeDropdown);
+
+  const handleDropdownItemButtonClick = (data: string) => {
+    onChange(data, name);
+    closeDropdown();
+  };
+
+  return (
+    <div ref={dropdownRef}>
+      <StyledDropdown onClick={handleToggleButtonClick} $isOpen={isOpen} $size={size}>
+        {value || placeholder}
+      </StyledDropdown>
+      <DropdownMenuBox $isOpen={isOpen}>
+        <DropdownMenu>
+          {data?.map((item, index) => (
+            <DropdownItem
+              key={`dropdown ${index}`}
+              onClick={() => handleDropdownItemButtonClick(item)}
+            >
+              {item}
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </DropdownMenuBox>
+    </div>
+  );
+};
+
+export default Dropdown;
+
+const StyledDropdown = styled.div<{ $isOpen: boolean; $size: DropdownOption }>`
+  ${flex({ alignItems: 'center', justifyContent: 'space-between' })}
+  width: ${({ $size }) => ($size === 'LARGE' ? '384px' : '334px')};
+  height: 42px;
+  padding: 14px 16px;
+  border: 1px solid ${({ $isOpen }) => ($isOpen ? color.G500 : color.G70)};
+  border-radius: 8px;
+  background: ${color.G0};
+  ${font.P3}
+  color: ${color.G900};
+  cursor: pointer;
+`;
+
+const DropdownMenuBox = styled.div<{ $isOpen: boolean }>`
+  position: relative;
+  display: ${({ $isOpen }) => ($isOpen ? 'block' : 'none')};
+`;
+
+const DropdownMenu = styled.div`
+  position: absolute;
+  display: grid;
+  width: 100%;
+  padding: 12px 0;
+  background: ${color.G0};
+  box-shadow:
+    0px 36px 10px 0px rgba(99, 99, 99, 0),
+    0px 23px 9px 0px rgba(99, 99, 99, 0.01),
+    0px 13px 8px 0px rgba(99, 99, 99, 0.05),
+    0px 6px 6px 0px rgba(99, 99, 99, 0.09),
+    0px 1px 3px 0px rgba(99, 99, 99, 0.1);
+  grid-template-columns: 1fr;
+  border-radius: 8px;
+  z-index: 1;
+`;
+
+const DropdownItem = styled.button`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  height: 42px;
+  padding: 11px 16px;
+  background: ${color.G0};
+  text-align: left;
+  ${font.P3}
+  color: ${color.G900};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${color.G20};
+  }
+`;

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -39,7 +39,7 @@ const Dropdown = ({
   return (
     <div ref={dropdownRef}>
       <Row gap={8}>
-        {value && option === 'COLOR' && <DropdownColorBox $color={value} />}
+        {option === 'COLOR' && <DropdownColorBox $color={value || '#FFFFFF'} />}
         <StyledDropdown
           onClick={handleToggleButtonClick}
           $isOpen={isOpen}

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 import { useBooleanState, useOutsideClick } from '@merried/hooks';
 import { flex } from '@merried/utils';
 import { color, font } from '@merried/design-system';
+import { IconArrow } from '@merried/icon';
 
 type DropdownOption = 'LARGE' | 'COLOR';
 
@@ -38,6 +39,7 @@ const Dropdown = ({
     <div ref={dropdownRef}>
       <StyledDropdown onClick={handleToggleButtonClick} $isOpen={isOpen} $size={size}>
         {value || placeholder}
+        <IconArrow direction={isOpen ? 'top' : 'bottom'} />
       </StyledDropdown>
       <DropdownMenuBox $isOpen={isOpen}>
         <DropdownMenu>

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -50,7 +50,7 @@ const Dropdown = ({
         </StyledDropdown>
       </Row>
       <DropdownMenuBox $isOpen={isOpen}>
-        <DropdownMenu>
+        <DropdownMenu $option={option}>
           {data?.map((item, index) => (
             <DropdownItem
               key={`dropdown ${index}`}
@@ -93,10 +93,11 @@ const DropdownMenuBox = styled.div<{ $isOpen: boolean }>`
   display: ${({ $isOpen }) => ($isOpen ? 'block' : 'none')};
 `;
 
-const DropdownMenu = styled.div`
+const DropdownMenu = styled.div<{ $option: DropdownOption }>`
   position: absolute;
+  right: 0;
   display: grid;
-  width: 100%;
+  width: ${({ $option }) => ($option === 'DEFAULT' ? '384px' : '334px')};
   padding: 12px 0;
   background: ${color.G0};
   box-shadow:

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -3,6 +3,7 @@ import { useBooleanState, useOutsideClick } from '@merried/hooks';
 import { flex } from '@merried/utils';
 import { color, font } from '@merried/design-system';
 import { IconArrow } from '@merried/icon';
+import Row from '../Flex/Row';
 
 type DropdownOption = 'DEFAULT' | 'COLOR';
 
@@ -37,10 +38,17 @@ const Dropdown = ({
 
   return (
     <div ref={dropdownRef}>
-      <StyledDropdown onClick={handleToggleButtonClick} $isOpen={isOpen} $option={option}>
-        {value || placeholder}
-        <IconArrow direction={isOpen ? 'top' : 'bottom'} />
-      </StyledDropdown>
+      <Row gap={8}>
+        {value && option === 'COLOR' && <DropdownColorBox $color={value} />}
+        <StyledDropdown
+          onClick={handleToggleButtonClick}
+          $isOpen={isOpen}
+          $option={option}
+        >
+          {value || placeholder}
+          <IconArrow direction={isOpen ? 'top' : 'bottom'} />
+        </StyledDropdown>
+      </Row>
       <DropdownMenuBox $isOpen={isOpen}>
         <DropdownMenu>
           {data?.map((item, index) => (
@@ -70,6 +78,14 @@ const StyledDropdown = styled.div<{ $isOpen: boolean; $option: DropdownOption }>
   ${font.P3}
   color: ${color.G900};
   cursor: pointer;
+`;
+
+const DropdownColorBox = styled.div<{ $color: string }>`
+  width: 42px;
+  height: 42px;
+  background: ${({ $color }) => $color};
+  border: 1px solid #a2a2a2;
+  border-radius: 8px;
 `;
 
 const DropdownMenuBox = styled.div<{ $isOpen: boolean }>`

--- a/packages/ui/src/Flex/Column.tsx
+++ b/packages/ui/src/Flex/Column.tsx
@@ -1,0 +1,25 @@
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+import type { FlexProps } from './Flex.type';
+
+const Column = ({
+  children,
+  gap,
+  justifyContent,
+  alignItems,
+  width,
+  height,
+  style,
+}: FlexProps) => {
+  return (
+    <StyledColumn style={{ gap, justifyContent, alignItems, width, height, ...style }}>
+      {children}
+    </StyledColumn>
+  );
+};
+
+export default Column;
+
+const StyledColumn = styled.div`
+  ${flex({ flexDirection: 'column' })}
+`;

--- a/packages/ui/src/Flex/Flex.type.ts
+++ b/packages/ui/src/Flex/Flex.type.ts
@@ -1,0 +1,11 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface FlexProps {
+  children: ReactNode;
+  gap?: CSSProperties['gap'];
+  justifyContent?: CSSProperties['justifyContent'];
+  alignItems?: CSSProperties['alignItems'];
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+  style?: CSSProperties;
+}

--- a/packages/ui/src/Flex/Row.tsx
+++ b/packages/ui/src/Flex/Row.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import type { FlexProps } from './Flex.type';
+
+const Row = ({
+  children,
+  gap,
+  justifyContent,
+  alignItems,
+  width,
+  height,
+  style,
+}: FlexProps) => {
+  return (
+    <StyledRow style={{ gap, justifyContent, alignItems, width, height, ...style }}>
+      {children}
+    </StyledRow>
+  );
+};
+
+export default Row;
+
+const StyledRow = styled.div`
+  display: flex;
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       '@merried/design-system':
         specifier: workspace:*
         version: link:../design-system
+      '@merried/hooks':
+        specifier: workspace:*
+        version: link:../hooks
       '@merried/icon':
         specifier: workspace:*
         version: link:../icon

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,10 +212,10 @@ importers:
         specifier: workspace:*
         version: link:../typescript-config
       '@types/react':
-        specifier: 19.0.10
+        specifier: ^19.0.0
         version: 19.0.10
       '@types/react-dom':
-        specifier: 19.0.4
+        specifier: ^19.0.0
         version: 19.0.4(@types/react@19.0.10)
       eslint:
         specifier: ^9.23.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,37 @@ importers:
         specifier: ^8.27.0
         version: 8.28.0(eslint@9.23.0)(typescript@5.8.2)
 
+  packages/hooks:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/react':
+        specifier: 19.0.10
+        version: 19.0.10
+      '@types/react-dom':
+        specifier: 19.0.4
+        version: 19.0.4(@types/react@19.0.10)
+      eslint:
+        specifier: ^9.23.0
+        version: 9.23.0
+      styled-reset:
+        specifier: ^4.4.7
+        version: 4.5.2(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+
   packages/icon:
     dependencies:
       react:
@@ -228,6 +259,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      styled-components:
+        specifier: ^6.1.17
+        version: 6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@merried/design-system':
         specifier: workspace:*
@@ -262,9 +296,6 @@ importers:
       eslint:
         specifier: ^9.23.0
         version: 9.23.0
-      styled-components:
-        specifier: ^6.1.17
-        version: 6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       styled-reset:
         specifier: ^4.4.7
         version: 4.5.2(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))


### PR DESCRIPTION
## 📄 Summary

> dropdown 컴포넌트를 추가하였습니다.

<br>

## 🔨 Tasks

- flex 컴포넌트(Row, Column) 추가
- usebooleanState 추가
- useOutsideClick 추가
- dropdown 컴포넌트(color, defalut) 추가

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/1e39bb47-5e72-4c5e-b46e-81a2a82bb8b8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - React용 커스텀 훅 패키지(@merried/hooks) 추가: useBooleanState, useOutsideClick 훅 제공
  - 새로운 Dropdown, Row, Column UI 컴포넌트 추가
  - IconArrow SVG 아이콘 컴포넌트 추가 및 공개
- **버그 수정**
  - 없음
- **문서화**
  - 없음
- **기타**
  - UI 패키지에서 Dropdown, Row, Column 컴포넌트 및 IconArrow 아이콘 사용 가능
  - 내부 개발 환경 및 타입스크립트, ESLint 설정 추가 및 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->